### PR TITLE
bug fixed: simulation speed control

### DIFF
--- a/src/core/simulation.js
+++ b/src/core/simulation.js
@@ -29,10 +29,12 @@ class Simulation {
     }
   }
 
-  step() {
+  step(currentSpeed) {
     this.flock.step();
 
     for (let boid of this.flock.boids) {
+      boid.maxSpeed = CONFIG.maxSpeed * currentSpeed;
+
       boid.update();
       this.wrap(boid);
     }

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,7 @@ const controls = new Controls();
 function loop() {
   const speed = controls.getSpeed();
   for (let i = 0; i < 1; i++) {
-    sim.step();
+    sim.step(speed);
   }
   renderer.render(controls);
   controls.updateFrame();


### PR DESCRIPTION
Previously, changing the simulation speed via the UI had no effect on the boids because
the speed multiplier never reached the individual boid's speed.

This update passes the speed control value directly into the simulation step loop,
ensuring that all boids are correctly updated according to the selected speed.