### PR TITLE
Fix incorrect x/y order when drawing velocity vectors

### DIFF
--- a/src/render/vectorRenderer.js
+++ b/src/render/vectorRenderer.js
@@ -3,7 +3,7 @@ class VectorRenderer {
     ctx.strokeStyle = "#45475a";
     ctx.lineWidth = 2;
     ctx.beginPath();
-    ctx.moveTo(boid.position.y, boid.position.x);
+    ctx.moveTo(boid.position.x, boid.position.y);
     ctx.lineTo(
       boid.position.x + boid.velocity.x * scale,
       boid.position.y + boid.velocity.y * scale


### PR DESCRIPTION
## Related Issue

Fixes #1

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Description

This PR fixes a rendering bug where the velocity vector was drawn using swapped
x and y coordinates. The incorrect `moveTo(y, x)` caused vectors to originate
from the wrong position on the canvas. This change corrects the vector origin
to use `(x, y)` as intended.

## Changes Made

- Fixed incorrect order of coordinates in `VectorRenderer.drawVelocityVector`

## Screenshots

**Before:**
Velocity vectors appeared offset or mirrored due to swapped coordinates.

<img width="1009" height="534" alt="image-1" src="https://github.com/user-attachments/assets/76b0efb5-56fe-4b62-9c67-2d4afdfa0da0" />

**After:**
Velocity vectors correctly originate from the boid position and align with their direction of motion.

<img width="1815" height="867" alt="image-2" src="https://github.com/user-attachments/assets/e5a79c1a-5c28-4954-921a-e0f6ed518ad3" />

## Testing Done

- [x] Tested locally
- [x] All existing features still work
- [x] No new warnings or errors

## Checklist

- [x] My code follows the style guidelines
- [x] I have reviewed my own code before submitting
- [x] My changes generate no new warnings
- [x] I have linked this PR to the issue using "Fixes #issue-number"
- [x] I have added descriptive commit messages

## Additional Notes

This is a visual-only fix and does not affect simulation logic or performance.
