### PR TITLE
feature: add pause/play via GUI and spacebar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,9 +16,11 @@ const renderer = new CanvasRenderer(canvas, flock);
 const controls = new Controls();
 
 function loop() {
-  const speed = controls.getSpeed();
-  for (let i = 0; i < Math.ceil(speed); i++) {
-    sim.step();
+  if (!controls.isPaused()) {
+    const speed = controls.getSpeed();
+    for (let i = 0; i < Math.ceil(speed); i++) {
+      sim.step();
+    }
   }
   renderer.render(controls);
   controls.updateFrame();

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -1,5 +1,6 @@
 class Controls {
   constructor() {
+    this.paused = false;
     this.vectorsEnabled = false;
     this.simulationSpeed = 1;
     this.maxSpeed = CONFIG.maxSpeed;
@@ -10,11 +11,14 @@ class Controls {
 
     this.gui = new lil.GUI({ title: "Controls" });
     this.createUI();
+    this.addListeners();
 
     this.startFPSCounter();
   }
 
   createUI() {
+    this.gui.add(this, "paused").name("Pause").listen();
+
     this.gui.add(this, "vectorsEnabled").name("Show Vectors");
 
     this.gui
@@ -36,6 +40,15 @@ class Controls {
     this.gui.add(this, "fps").name("FPS").listen();
   }
 
+  addListeners() {
+    window.addEventListener("keydown", (event) => {
+      if (event.code === "Space") {
+        event.preventDefault();
+        this.togglePause();
+      }
+    });
+
+  }
   startFPSCounter() {
     setInterval(() => {
       const now = performance.now();
@@ -57,5 +70,13 @@ class Controls {
 
   getSpeed() {
     return this.simulationSpeed;
+  }
+
+  isPaused() {
+    return this.paused;
+  }
+
+  togglePause() {
+    return (this.paused = !this.paused);
   }
 }


### PR DESCRIPTION
## Related Issue

Fixes #6

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Description

This PR adds a pause/play feature to the simulation. Users can now pause and
resume the simulation either through the GUI or by pressing the spacebar.

The pause state is managed within the `Controls` class and is synchronized
between the lil-gui checkbox and keyboard input. Pausing stops the simulation logic, but the visuals and animation loop keep running.

## Changes Made

- Added `paused` state to the `Controls` class
- Added pause toggle control (synchronized GUI checkbox) to the lil-gui interface
- Added `addListeners()` method to handle keyboard input
- Implemented spacebar event listener to toggle pause state
- Added helper methods `isPaused()` and `togglePause()`


## Testing Done

- [x] Tested locally
- [x] All existing features still work
- [x] No new warnings or errors

## Checklist

- [x] My code follows the style guidelines
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have reviewed my own code before submitting
- [x] My changes generate no new warnings
- [x] I have linked this PR to the issue using "Fixes #issue-number"
- [x] I have added descriptive commit messages

## Additional Notes

This feature pauses simulation updates without stopping the animation loop, preventing the application from feeling frozen and avoiding timing issues when resuming.

