### PR TITLE
fixed trail flickering problem

### DIFF
--- a/src/render/canvasRenderer.js
+++ b/src/render/canvasRenderer.js
@@ -14,18 +14,21 @@ class CanvasRenderer {
       ctx.lineCap = "round";
       ctx.lineJoin = "round";
 
-    for (let i = 1; i < boid.trail.length; i++) {
-        const init=boid.trail[i-1];
-        const final=boid.trail[i];
-        const pixelbuffer=5;
-        const dist=((final.x-init.x)**2 + (final.y-init.y)**2)**0.5
+      for (let i = 1; i < boid.trail.length; i++) {
+        const init = boid.trail[i - 1];
+        const final = boid.trail[i];
+        const pixelbuffer = 5;
+        const dist = ((final.x - init.x) ** 2 + (final.y - init.y) ** 2) ** 0.5;
 
-        ctx.globalAlpha = i**2 / boid.trail.length**2;
+        ctx.globalAlpha = i ** 2 / boid.trail.length ** 2;
         ctx.beginPath();
         ctx.moveTo(init.x, init.y);
-        ctx.lineTo(init.x + ((pixelbuffer/dist)*(final.x-init.x)), init.y + ((pixelbuffer/dist)*(final.y-init.y)));
+        ctx.lineTo(
+          init.x + (pixelbuffer / dist) * (final.x - init.x),
+          init.y + (pixelbuffer / dist) * (final.y - init.y)
+        );
         ctx.stroke();
-      }    
+      }
       ctx.globalAlpha = 1.0;
     }
 
@@ -39,13 +42,12 @@ class CanvasRenderer {
     ctx.fill();
   }
 
-  render(controls) { 
-    
-    window.addEventListener('resize',() =>{
-      this.canvas.width=sim.width=window.innerWidth;
-      this.canvas.height=sim.height=window.innerHeight;
-    })
-      
+  render(controls) {
+    window.addEventListener("resize", () => {
+      this.canvas.width = sim.width = window.innerWidth;
+      this.canvas.height = sim.height = window.innerHeight;
+    });
+
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     const showVectors = controls ? controls.shouldDrawVectors() : true;
     for (let b of this.flock.boids) this.drawBoid(b, showVectors);


### PR DESCRIPTION
Fixed trail flickering issue by changing globalAlpha from random values to instead increasing as the trail length increases.

Noticed an issue where the trail was being rendered in chunks and not as a smooth gradient. The issue is caused by not enough samples for the trail position. Issue can be recreated by setting the pixelbuffer value to 0. 
<img width="216" height="177" alt="image" src="https://github.com/user-attachments/assets/bbf88879-eb11-4344-8bb7-b2492a35b69e" />


Fixed by drawing the trail a bit further than the position (as determined by the pixel buffer) and thus giving a more smooth gradient.

<img width="324" height="190" alt="image" src="https://github.com/user-attachments/assets/33de79fc-1108-406a-9910-817b7b38154a" />
