### PR TITLE
Fixes #9: add mag method

### DIFF
--- a/src/utils/vector.js
+++ b/src/utils/vector.js
@@ -3,6 +3,10 @@ class Vec {
     this.x = x;
     this.y = y;
   }
+  
+  mag() {
+    return Math.sqrt(this.x * this.x + this.y * this.y);
+  }
 
   add(v) {
     this.x += v.x;


### PR DESCRIPTION
Fixes #9 

Add mag() method in Vector class
- Introduces a mag() method on the Vector class, which returns the Euclidean magnitude (length) of a vector

Why this change?
- The vector implementation previously lacked a direct magnitude method
- Avoids duplicated Math.sqrt() logic

Behavior
- Returns magnitude
- Does not mutate state
- Can be reused by other vector methods